### PR TITLE
Fix broken documentation links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,8 +284,10 @@ See [DESIGN_SPEC.md](DESIGN_SPEC.md) for complete architecture details.
 - [Evaluator Registry](examples/evaluator_registry_example.py) - Custom evaluators
 
 ### API Documentation
-- **[docs/api/](docs/api/)** - Complete API reference (16 pages)
-- **[docs/guides/](docs/guides/)** - In-depth guides and tutorials
+- **[docs/api/](docs/api/)** - Complete API reference
+- **[docs/evaluator-registry.md](docs/evaluator-registry.md)** - Custom evaluator registration guide
+- **[docs/multiple-evaluators.md](docs/multiple-evaluators.md)** - Combining multiple evaluators
+- **[docs/TOOLS_PLUGIN_ARCHITECTURE.md](docs/TOOLS_PLUGIN_ARCHITECTURE.md)** - Tools & plugins architecture (Phase 5)
 - **[MkDocs Setup](mkdocs.yml)** - Documentation site configuration
 
 ## Development


### PR DESCRIPTION
## Summary

Fixes broken documentation links in README.md by replacing non-existent `docs/guides/` reference with actual documentation files.

## Changes

- ❌ Removed: `docs/guides/` (directory doesn't exist)
- ✅ Added: `docs/evaluator-registry.md` - Custom evaluator registration guide
- ✅ Added: `docs/multiple-evaluators.md` - Combining multiple evaluators guide
- ✅ Added: `docs/TOOLS_PLUGIN_ARCHITECTURE.md` - Phase 5 tools/plugins architecture

## Verification

All referenced documentation files now exist in the repository.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)