### PR TITLE
Add First-Time Contributors section to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,7 @@ Thank you for your interest in contributing to Arbiter! This document provides g
 
 ## Table of Contents
 
+- [First-Time Contributors](#first-time-contributors)
 - [Code of Conduct](#code-of-conduct)
 - [Getting Started](#getting-started)
 - [Development Setup](#development-setup)
@@ -12,6 +13,24 @@ Thank you for your interest in contributing to Arbiter! This document provides g
 - [Code Quality](#code-quality)
 - [Pull Request Process](#pull-request-process)
 - [Issue Guidelines](#issue-guidelines)
+
+## First-Time Contributors
+
+If this is your first open-source contribution — welcome! 🎉
+
+You do not need to understand the entire codebase before contributing.
+Small contributions are appreciated, including:
+- Documentation improvements
+- Fixing typos
+- Adding examples
+- Improving comments
+
+If you are unsure where to start, look for issues labeled
+`good first issue` or `documentation`.
+
+Feel free to ask questions by opening an issue — we are happy to help.
+
+
 
 ## Code of Conduct
 


### PR DESCRIPTION
Fixes #50

### Summary
Added a new section in CONTRIBUTING.md for first-time contributors. 
This section welcomes new contributors, explains that they do not need to understand 
the full codebase to contribute, and lists small ways they can help (documentation 
improvements, fixing typos, adding examples, improving comments). 

### Motivation
This helps beginners get started more easily and encourages contributions by 
pointing them to `good first issue` and `documentation` labels.

### Changes Made
- Added "First-Time Contributors" section above Code of Conduct.
- Updated Table of Contents to include the new section.
- Included guidance for asking questions and getting help.

### Notes
No code changes, only documentation.

