### PR TITLE
docs: Add pre-commit install to README Development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,6 +495,9 @@ cd arbiter
 # Install with development dependencies
 uv sync --all-extras
 
+# Install pre-commit hooks (auto-formats code on commit)
+uv run pre-commit install
+
 # Run tests
 uv run pytest
 


### PR DESCRIPTION
## Summary
Follow-up to #86. Adds the `uv run pre-commit install` command to the README's Development section.

## Changes
- Added one line to the Development setup instructions

## Why
The pre-commit config was added in #86, but the README didn't tell contributors to run `pre-commit install`. This ensures new contributors see the step when following the setup instructions.