### PR TITLE
Add retry logic with max delay and jitter

### DIFF
--- a/arbiter_ai/core/retry.py
+++ b/arbiter_ai/core/retry.py
@@ -97,7 +97,14 @@ class RetryConfig:
         max_delay: Maximum delay between retries (must be > 0)
     """
 
-    def __init__(self, max_attempts: int = 3, delay: float = 1.0, backoff: float = 2.0, jitter: bool = True, max_delay: float = 60.0):
+    def __init__(
+        self,
+        max_attempts: int = 3,
+        delay: float = 1.0,
+        backoff: float = 2.0,
+        jitter: bool = True,
+        max_delay: float = 60.0,
+    ):
         """Initialize retry configuration with validation.
 
         Args:
@@ -196,7 +203,7 @@ def with_retry(
 
                     if attempt < config.max_attempts:
                         await asyncio.sleep(delay)
-                        delay = config.delay * (config.backoff ** attempt)
+                        delay = config.delay * (config.backoff**attempt)
                         if config.jitter:
                             delay += random.uniform(0, delay * 0.25)
                         delay = min(delay, config.max_delay)
@@ -216,7 +223,9 @@ def with_retry(
 # Preset configurations
 # These provide common retry strategies for different scenarios
 
-RETRY_QUICK = RetryConfig(max_attempts=2, delay=0.5, backoff=1.5, jitter=True, max_delay=45.0)
+RETRY_QUICK = RetryConfig(
+    max_attempts=2, delay=0.5, backoff=1.5, jitter=True, max_delay=45.0
+)
 """Quick retry for fast operations with minimal delay.
 
 Use this for:
@@ -227,7 +236,9 @@ Use this for:
 Timing: 0.5s + jitter = ~0.5-0.625s total delay
 """
 
-RETRY_STANDARD = RetryConfig(max_attempts=3, delay=1.0, backoff=2.0, jitter=True, max_delay=60.0)
+RETRY_STANDARD = RetryConfig(
+    max_attempts=3, delay=1.0, backoff=2.0, jitter=True, max_delay=60.0
+)
 """Standard retry configuration suitable for most API calls.
 
 Use this for:
@@ -238,7 +249,9 @@ Use this for:
 Timing: 1s, 2s + jitter = ~3-3.75s total delay
 """
 
-RETRY_PERSISTENT = RetryConfig(max_attempts=5, delay=1.0, backoff=2.0, jitter=True, max_delay=90.0)
+RETRY_PERSISTENT = RetryConfig(
+    max_attempts=5, delay=1.0, backoff=2.0, jitter=True, max_delay=90.0
+)
 """Persistent retry for critical operations that must succeed.
 
 Use this for:

--- a/arbiter_ai/verifiers/citation_verifier.py
+++ b/arbiter_ai/verifiers/citation_verifier.py
@@ -103,9 +103,7 @@ class CitationVerifier(FactualityVerifier):
 
         # Check for key terms overlap (medium confidence)
         claim_words = set(
-            word
-            for word in claim_lower.split()
-            if len(word) > 3  # Skip short words
+            word for word in claim_lower.split() if len(word) > 3  # Skip short words
         )
         context_words = set(context_lower.split())
 

--- a/tests/unit/test_cost_calculator.py
+++ b/tests/unit/test_cost_calculator.py
@@ -504,9 +504,9 @@ class TestLiteLLMIntegration:
         common_models = ["gpt-4o-mini", "gpt-4o", "claude-sonnet-4-5-20250929"]
 
         for model in common_models:
-            assert model in litellm.model_cost, (
-                f"Expected {model} in litellm.model_cost"
-            )
+            assert (
+                model in litellm.model_cost
+            ), f"Expected {model} in litellm.model_cost"
             assert litellm.model_cost[model].get("input_cost_per_token") is not None
 
     def test_real_calculator_loads_many_models(self):

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -243,22 +243,22 @@ class TestMultiEvaluatorErrorHandling:
         assert result.scores[0].name == "semantic", "Should have semantic score"
         assert "custom_criteria" in result.errors, "custom_criteria should be in errors"
         # Error message includes details formatting
-        assert "API timeout" in result.errors["custom_criteria"], (
-            "Error message should contain 'API timeout'"
-        )
+        assert (
+            "API timeout" in result.errors["custom_criteria"]
+        ), "Error message should contain 'API timeout'"
 
         # Verify overall score is calculated from successful evaluators only
-        assert result.overall_score == 0.85, (
-            "Overall score should be semantic score (0.85), not average"
-        )
+        assert (
+            result.overall_score == 0.85
+        ), "Overall score should be semantic score (0.85), not average"
         assert result.metadata["successful_evaluators"] == 1
         assert result.metadata["failed_evaluators"] == 1
 
         # Verify we can still use the result
         assert result.passed is True, "Should pass threshold (0.85 > 0.7)"
-        assert len(result.interactions) > 0, (
-            "Should have interactions from successful evaluator"
-        )
+        assert (
+            len(result.interactions) > 0
+        ), "Should have interactions from successful evaluator"
 
     @pytest.mark.asyncio
     async def test_multiple_evaluators_partial_failure(

--- a/tests/unit/test_evaluator_naming_consistency.py
+++ b/tests/unit/test_evaluator_naming_consistency.py
@@ -72,9 +72,9 @@ async def test_semantic_evaluator_name_consistency(mock_llm_client):
     score = await evaluator.evaluate(output="Test output", reference="Test reference")
 
     # Critical check: score name must match evaluator name
-    assert score.name == evaluator_name, (
-        f"Score name '{score.name}' does not match evaluator name '{evaluator_name}'"
-    )
+    assert (
+        score.name == evaluator_name
+    ), f"Score name '{score.name}' does not match evaluator name '{evaluator_name}'"
 
 
 @pytest.mark.asyncio
@@ -89,9 +89,9 @@ async def test_custom_criteria_evaluator_name_consistency(mock_llm_client):
     score = await evaluator.evaluate(output="Test output", criteria="Test criteria")
 
     # Critical check: score name must match evaluator name
-    assert score.name == evaluator_name, (
-        f"Score name '{score.name}' does not match evaluator name '{evaluator_name}'"
-    )
+    assert (
+        score.name == evaluator_name
+    ), f"Score name '{score.name}' does not match evaluator name '{evaluator_name}'"
 
 
 def test_registry_name_matches_evaluator_name():
@@ -99,9 +99,9 @@ def test_registry_name_matches_evaluator_name():
     for registry_name, evaluator_class in AVAILABLE_EVALUATORS.items():
         # Create instance (need to handle constructor requirements)
         # For now, just check the name property exists
-        assert hasattr(evaluator_class, "name"), (
-            f"Evaluator {evaluator_class} missing name property"
-        )
+        assert hasattr(
+            evaluator_class, "name"
+        ), f"Evaluator {evaluator_class} missing name property"
 
         # Note: We can't easily instantiate without proper LLM client,
         # but we can check the property is defined
@@ -112,9 +112,9 @@ def test_all_builtin_evaluators_registered():
     expected_evaluators = ["semantic", "custom_criteria"]
 
     for evaluator_name in expected_evaluators:
-        assert evaluator_name in AVAILABLE_EVALUATORS, (
-            f"Built-in evaluator '{evaluator_name}' not registered"
-        )
+        assert (
+            evaluator_name in AVAILABLE_EVALUATORS
+        ), f"Built-in evaluator '{evaluator_name}' not registered"
 
 
 def test_registry_lookup_returns_correct_class():

--- a/tests/unit/test_retry.py
+++ b/tests/unit/test_retry.py
@@ -29,7 +29,9 @@ class TestRetryConfig:
 
     def test_initialization_custom(self):
         """Test RetryConfig with custom values."""
-        config = RetryConfig(max_attempts=5, delay=2.0, backoff=1.5, jitter=False, max_delay=30.0)
+        config = RetryConfig(
+            max_attempts=5, delay=2.0, backoff=1.5, jitter=False, max_delay=30.0
+        )
 
         assert config.max_attempts == 5
         assert config.delay == 2.0


### PR DESCRIPTION
## Description

Enhanced the existing `with_retry` decorator with jitter and max delay support to improve retry behavior and prevent thundering herd issues.

**Changes:**

- Added `jitter` parameter (default: `True`) to `RetryConfig` that adds 0-25% random delay to prevent synchronized retries
- Added `max_delay` parameter (default: `60.0s`) to `RetryConfig` that caps exponential backoff delays
- Updated preset configurations (`RETRY_QUICK`, `RETRY_STANDARD`, `RETRY_PERSISTENT`) with appropriate jitter and max_delay values
- Updated docstrings with accurate timing calculations including jitter ranges

**Files Modified:**

- `arbiter_ai/core/retry.py` - Added jitter and max_delay to RetryConfig and with_retry decorator
- `tests/unit/test_retry.py` - Added tests for new functionality

## Type of Change

- [ ] Bug fix
- [ ] New evaluator
- [x] Enhancement
- [x] Documentation

## Testing

- [x] Added unit tests
- [ ] Added integration tests
- [x] All tests pass
- [x] Coverage >80%

**New tests added:**

- `test_validation_max_delay_zero_or_negative` - validates max_delay parameter
- `test_max_delay_caps_exponential_backoff` - verifies delay capping behavior
- `test_jitter_adds_randomness` - verifies jitter adds expected randomness
- Updated existing tests to verify new `jitter` and `max_delay` attributes

## Checklist

- [x] Code follows style guidelines (black, ruff, mypy pass)
- [x] Added/updated docstrings
- [ ] Updated README.md if needed
- [ ] Added example in examples/ if needed
- [ ] Updated **init**.py exports

Closes #75 