### PR TITLE
chore: Add .editorconfig for consistent formatting (#66)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+# EditorConfig: https://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.py]
+indent_size = 4
+max_line_length = 88
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.{json,toml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
## Summary

Adds `.editorconfig` file to ensure consistent formatting across different editors and IDEs.

## Configuration

| File Type | Indent | Line Length |
|-----------|--------|-------------|
| Python (*.py) | 4 spaces | 88 (matches Black) |
| YAML/JSON/TOML | 2 spaces | - |
| Makefile | tabs | - |
| Markdown | 4 spaces | trailing whitespace preserved |

## Benefits

- Contributors maintain consistent style without manual editor configuration
- Most modern editors support EditorConfig natively or via plugin
- Complements Black/Ruff for Python formatting

## References

- https://editorconfig.org

Closes #66