### PR TITLE
feat: Add filtering methods to BatchEvaluationResult (#73)

### DIFF
--- a/tests/unit/test_middleware.py
+++ b/tests/unit/test_middleware.py
@@ -751,10 +751,11 @@ class TestMemoryCacheBackendAdvanced:
         result = await backend.get("key1")
         assert result == "value1"
 
-        # Mock time in middleware module to simulate expiration
+        # Mock time in cache_backends module to simulate expiration
         original_time = time.time()
         with patch(
-            "arbiter_ai.core.middleware.time.time", return_value=original_time + 2
+            "arbiter_ai.core.middleware.cache_backends.time.time",
+            return_value=original_time + 2,
         ):
             # Value should be expired and return None
             result = await backend.get("key1")


### PR DESCRIPTION
## Summary

- Add `filter()` method: filter results by passed status and score thresholds
- Add `slice()` method: get results by index range with standard Python semantics
- Add `get_failed_items()` method: retrieve items that failed evaluation
- Add `get_results_with_indices()` method: get results paired with position context

## Usage Examples

```python
batch_result = await batch_evaluate(items, evaluators=["semantic"])

# Get only passed results
passed = batch_result.filter(passed=True)

# Get results above a score threshold
high_quality = batch_result.filter(min_score=0.9)

# Combine filters: failed but close to threshold
needs_review = batch_result.filter(passed=False, min_score=0.6)

# Get results by index range
first_ten = batch_result.slice(0, 10)

# Get items that had errors
errored = batch_result.get_failed_items()

# Get results with their indices for correlation
for idx, result in batch_result.get_results_with_indices():
    if result:
        print(f"Item {idx}: score={result.overall_score}")
```

## Test Plan

- [x] 23 unit tests covering all filtering methods
- [x] Tests for edge cases: empty batches, None results, out-of-range slices
- [x] Tests verify filter excludes None results
- [x] Tests verify get_failed_items returns a copy
- [x] make all passes (except pre-existing flaky timeout test)

Closes #73