### PR TITLE
fix: Improve Pydantic validation consistency and security

### DIFF
--- a/arbiter_ai/evaluators/custom_criteria.py
+++ b/arbiter_ai/evaluators/custom_criteria.py
@@ -93,7 +93,7 @@ class CustomCriteriaResponse(BaseModel):
         """Ensure criteria are identified for non-trivial assessments."""
         total_criteria = len(self.criteria_met) + len(self.criteria_not_met)
         if (
-            self.confidence > 0.7
+            self.confidence > 0.9
             and total_criteria == 0
             and self.score not in (0.0, 1.0)
         ):

--- a/arbiter_ai/evaluators/factuality.py
+++ b/arbiter_ai/evaluators/factuality.py
@@ -93,7 +93,7 @@ class FactualityResponse(BaseModel):
             + len(self.non_factual_claims)
             + len(self.uncertain_claims)
         )
-        if self.confidence > 0.7 and total_claims == 0 and self.score not in (0.0, 1.0):
+        if self.confidence > 0.9 and total_claims == 0 and self.score not in (0.0, 1.0):
             raise ValueError(
                 "High confidence scores (>0.9) require at least one claim to be identified"
             )

--- a/arbiter_ai/evaluators/groundedness.py
+++ b/arbiter_ai/evaluators/groundedness.py
@@ -88,7 +88,7 @@ class GroundednessResponse(BaseModel):
             self.ungrounded_statements
         )
         if (
-            self.confidence > 0.7
+            self.confidence > 0.9
             and total_statements == 0
             and self.score not in (0.0, 1.0)
         ):

--- a/arbiter_ai/evaluators/relevance.py
+++ b/arbiter_ai/evaluators/relevance.py
@@ -88,7 +88,7 @@ class RelevanceResponse(BaseModel):
             + len(self.missing_points)
             + len(self.irrelevant_content)
         )
-        if self.confidence > 0.7 and total_points == 0 and self.score not in (0.0, 1.0):
+        if self.confidence > 0.9 and total_points == 0 and self.score not in (0.0, 1.0):
             raise ValueError(
                 "High confidence scores (>0.9) require at least one point to be identified"
             )

--- a/arbiter_ai/evaluators/similarity_backends.py
+++ b/arbiter_ai/evaluators/similarity_backends.py
@@ -17,7 +17,7 @@ Example:
 from typing import Any, Dict, Protocol
 
 import numpy as np
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from ..core.llm_client import LLMClient
 
@@ -31,6 +31,12 @@ __all__ = [
 
 class SimilarityResult(BaseModel):
     """Result from similarity computation."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        str_strip_whitespace=True,
+        validate_assignment=True,
+    )
 
     score: float = Field(
         ge=0.0, le=1.0, description="Similarity score (0=different, 1=identical)"

--- a/arbiter_ai/storage/postgres.py
+++ b/arbiter_ai/storage/postgres.py
@@ -8,6 +8,7 @@ Reads DATABASE_URL from environment for database connection.
 import json
 import logging
 import os
+import re
 import uuid
 from typing import Any, Optional
 
@@ -60,6 +61,18 @@ class PostgresStorage(StorageBackend):
         if not self.database_url:
             raise ValueError(
                 "DATABASE_URL must be provided or set in environment variables"
+            )
+
+        # Validate schema name to prevent SQL injection
+        # Schema names must be valid PostgreSQL identifiers:
+        # - Start with a letter or underscore
+        # - Contain only letters, digits, and underscores
+        # - Maximum 63 characters (PostgreSQL limit)
+        if not re.match(r"^[a-zA-Z_][a-zA-Z0-9_]{0,62}$", schema):
+            raise ValueError(
+                f"Invalid schema name '{schema}'. Schema names must start with a letter "
+                "or underscore, contain only letters, digits, and underscores, "
+                "and be at most 63 characters."
             )
 
         self.schema = schema


### PR DESCRIPTION
## Summary

- Add `ConfigDict` to `SimilarityResult` model for strict validation (rejects unknown fields)
- Standardize model validator confidence thresholds from `0.7` to `0.9` to match error messages
- Add schema name validation to PostgreSQL storage backend to prevent SQL injection

## Changes

### 1. SimilarityResult ConfigDict (`similarity_backends.py`)
Added missing `ConfigDict` to ensure the model follows the same strict validation pattern as all other Pydantic models in the codebase:
```python
model_config = ConfigDict(
    extra="forbid",
    str_strip_whitespace=True,
    validate_assignment=True,
)
```

### 2. Validator Threshold Consistency
Fixed inconsistency where error messages said ">0.9" but code checked `> 0.7`:

| File | Change |
|------|--------|
| `custom_criteria.py` | `0.7` → `0.9` |
| `factuality.py` | `0.7` → `0.9` |
| `groundedness.py` | `0.7` → `0.9` |
| `relevance.py` | `0.7` → `0.9` |

### 3. PostgreSQL Schema Validation (`postgres.py`)
Added SQL injection prevention for the schema parameter:
```python
if not re.match(r"^[a-zA-Z_][a-zA-Z0-9_]{0,62}$", schema):
    raise ValueError(...)
```

## Test plan

- [x] `make format` - All files unchanged
- [x] `make lint` - All checks passed
- [x] `make type-check` - No issues in 46 files
- [x] `make test` - 891 passed, 1 skipped, 95% coverage