### PR TITLE
feat: Add InstructionFollowingEvaluator for agent/pipeline validation

### DIFF
--- a/arbiter_ai/__init__.py
+++ b/arbiter_ai/__init__.py
@@ -41,6 +41,7 @@ interaction tracking, multiple evaluators, and extensible architecture.
 - **FactualityEvaluator**: Hallucination detection and fact verification
 - **GroundednessEvaluator**: RAG system validation and source attribution
 - **RelevanceEvaluator**: Query-output alignment and completeness assessment
+- **InstructionFollowingEvaluator**: Agent/pipeline validation for instruction adherence
 - **PairwiseComparisonEvaluator**: A/B testing and model comparison
 
 ## Main Components:
@@ -128,6 +129,7 @@ from .evaluators import (
     CustomCriteriaEvaluator,
     FactualityEvaluator,
     GroundednessEvaluator,
+    InstructionFollowingEvaluator,
     PairwiseComparisonEvaluator,
     RelevanceEvaluator,
     SemanticEvaluator,
@@ -153,6 +155,7 @@ __all__ = [
     "CustomCriteriaEvaluator",
     "FactualityEvaluator",
     "GroundednessEvaluator",
+    "InstructionFollowingEvaluator",
     "RelevanceEvaluator",
     "PairwiseComparisonEvaluator",
     "BasePydanticEvaluator",

--- a/arbiter_ai/core/registry.py
+++ b/arbiter_ai/core/registry.py
@@ -55,6 +55,7 @@ def _initialize_builtin_evaluators() -> None:
         CustomCriteriaEvaluator,
         FactualityEvaluator,
         GroundednessEvaluator,
+        InstructionFollowingEvaluator,
         RelevanceEvaluator,
         SemanticEvaluator,
     )
@@ -63,6 +64,7 @@ def _initialize_builtin_evaluators() -> None:
     AVAILABLE_EVALUATORS["custom_criteria"] = CustomCriteriaEvaluator
     AVAILABLE_EVALUATORS["factuality"] = FactualityEvaluator
     AVAILABLE_EVALUATORS["groundedness"] = GroundednessEvaluator
+    AVAILABLE_EVALUATORS["instruction_following"] = InstructionFollowingEvaluator
     AVAILABLE_EVALUATORS["relevance"] = RelevanceEvaluator
 
 

--- a/arbiter_ai/evaluators/__init__.py
+++ b/arbiter_ai/evaluators/__init__.py
@@ -4,9 +4,10 @@ This module provides evaluators for different aspects of LLM outputs:
 - Semantic similarity between output and reference (LLM or FAISS backend)
 - Custom criteria evaluation (domain-specific quality checks)
 - Factuality checking and hallucination detection
+- Instruction following validation for agents and pipelines
 - Pairwise comparison for A/B testing
-- Consistency evaluation (planned)
-- Relevance scoring (planned)
+- Groundedness assessment for RAG systems
+- Relevance scoring for query alignment
 
 All evaluators inherit from BasePydanticEvaluator and automatically
 track LLM interactions for full observability.
@@ -24,6 +25,10 @@ from .custom_criteria import (
 )
 from .factuality import FactualityEvaluator, FactualityResponse
 from .groundedness import GroundednessEvaluator, GroundednessResponse
+from .instruction_following import (
+    InstructionFollowingEvaluator,
+    InstructionFollowingResponse,
+)
 from .pairwise import (
     AspectComparison,
     PairwiseComparisonEvaluator,
@@ -50,6 +55,8 @@ __all__ = [
     "FactualityResponse",
     "GroundednessEvaluator",
     "GroundednessResponse",
+    "InstructionFollowingEvaluator",
+    "InstructionFollowingResponse",
     "RelevanceEvaluator",
     "RelevanceResponse",
     "PairwiseComparisonEvaluator",

--- a/arbiter_ai/evaluators/instruction_following.py
+++ b/arbiter_ai/evaluators/instruction_following.py
@@ -1,0 +1,296 @@
+"""Instruction following evaluator for validating LLM output adherence to constraints.
+
+This evaluator measures how well an LLM output follows given instructions or
+constraints. It is critical for agents, tool use, structured outputs, and any
+pipeline with specific requirements.
+
+## When to Use:
+
+- Validating agent outputs follow specific formats (JSON, markdown, etc.)
+- Checking structured output compliance
+- Ensuring content constraints are met (required fields, length limits)
+- Verifying tone/style requirements
+- Testing LLM pipelines with explicit instructions
+
+## Example:
+
+    >>> evaluator = InstructionFollowingEvaluator(llm_client)
+    >>> score = await evaluator.evaluate(
+    ...     output='{"name": "Alice", "age": 30}',
+    ...     criteria="Respond in valid JSON. Include 'name' and 'age' fields."
+    ... )
+    >>> print(f"Score: {score.value:.2f}")
+    >>> print(f"Violations: {score.metadata.get('instructions_violated', [])}")
+
+## Evaluation Aspects:
+
+The evaluator assesses:
+- Format requirements (JSON, markdown, bullet points, etc.)
+- Content constraints (required fields, topics to include/exclude)
+- Length/word count limits
+- Tone/style requirements
+- Any explicit instructions provided in criteria
+"""
+
+from typing import List, Literal, Optional, Type, cast
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from ..core.models import Score
+from .base import BasePydanticEvaluator
+
+__all__ = ["InstructionFollowingEvaluator", "InstructionFollowingResponse"]
+
+
+ViolationSeverity = Literal["none", "minor", "major", "critical"]
+
+
+class InstructionFollowingResponse(BaseModel):
+    """Structured response for instruction following evaluation."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        str_strip_whitespace=True,
+        validate_assignment=True,
+    )
+
+    score: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Instruction adherence score (0=ignored instructions, 1=fully followed)"
+        ),
+    )
+    confidence: float = Field(
+        default=0.85,
+        ge=0.0,
+        le=1.0,
+        description="Confidence in this instruction adherence assessment",
+    )
+    explanation: str = Field(
+        ..., description="Detailed explanation of how well instructions were followed"
+    )
+    instructions_followed: List[str] = Field(
+        default_factory=list,
+        description="List of instructions that were successfully followed",
+    )
+    instructions_violated: List[str] = Field(
+        default_factory=list,
+        description="List of instructions that were not followed",
+    )
+    instructions_partially_met: List[str] = Field(
+        default_factory=list,
+        description="List of instructions that were only partially followed",
+    )
+    violation_severity: ViolationSeverity = Field(
+        default="none",
+        description=(
+            "Overall severity of violations: "
+            "'none' (all followed), "
+            "'minor' (small deviations), "
+            "'major' (significant issues), "
+            "'critical' (fundamental violations)"
+        ),
+    )
+
+    @field_validator("explanation")
+    @classmethod
+    def validate_explanation_quality(cls, v: str) -> str:
+        """Ensure explanation is meaningful and not empty."""
+        if len(v.strip()) < 1:
+            raise ValueError("Explanation cannot be empty")
+        return v.strip()
+
+    @model_validator(mode="after")
+    def validate_instruction_analysis(self) -> "InstructionFollowingResponse":
+        """Ensure violation severity matches instruction counts."""
+        has_violations = len(self.instructions_violated) > 0
+        has_partial = len(self.instructions_partially_met) > 0
+
+        # If no violations or partial, severity should be 'none' or possibly 'minor'
+        if (
+            not has_violations
+            and not has_partial
+            and self.violation_severity
+            not in (
+                "none",
+                "minor",
+            )
+        ):
+            raise ValueError(
+                f"Violation severity '{self.violation_severity}' is inconsistent "
+                "with no violated or partially met instructions"
+            )
+
+        # If violations exist but severity is 'none', that's inconsistent
+        if has_violations and self.violation_severity == "none":
+            raise ValueError(
+                "Violation severity cannot be 'none' when instructions are violated"
+            )
+
+        return self
+
+
+class InstructionFollowingEvaluator(BasePydanticEvaluator):
+    """Evaluates how well LLM output follows given instructions.
+
+    This evaluator analyzes whether an output adheres to specified instructions
+    or constraints. It is essential for validating agent behavior, structured
+    outputs, and any LLM pipeline with explicit requirements.
+
+    The evaluator:
+    - Identifies each instruction/constraint in the criteria
+    - Checks if the output follows each instruction
+    - Categorizes instructions as followed, violated, or partially met
+    - Assesses the severity of any violations
+    - Provides detailed explanation of adherence/violations
+
+    Example:
+        >>> from arbiter_ai import LLMManager
+        >>> client = await LLMManager.get_client(model="gpt-4o")
+        >>> evaluator = InstructionFollowingEvaluator(client)
+        >>>
+        >>> # Check JSON format compliance
+        >>> score = await evaluator.evaluate(
+        ...     output='{"name": "Alice", "age": 30}',
+        ...     criteria="Respond in valid JSON. Include 'name' and 'age' fields."
+        ... )
+        >>> print(f"Score: {score.value:.2f}")
+        >>>
+        >>> # Check multiple constraints
+        >>> score = await evaluator.evaluate(
+        ...     output="Here is a brief summary of the topic...",
+        ...     criteria=(
+        ...         "1. Keep response under 100 words. "
+        ...         "2. Use bullet points. "
+        ...         "3. Include a conclusion."
+        ...     )
+        ... )
+        >>> print(f"Followed: {score.metadata.get('instructions_followed', [])}")
+        >>> print(f"Violated: {score.metadata.get('instructions_violated', [])}")
+    """
+
+    @property
+    def name(self) -> str:
+        """Return evaluator identifier."""
+        return "instruction_following"
+
+    def _get_system_prompt(self) -> str:
+        """Get system prompt defining instruction following evaluation approach."""
+        return """You are an expert evaluator specializing in assessing instruction adherence.
+
+Your task is to analyze how well a given output follows specified instructions or constraints.
+
+For each instruction/constraint, determine:
+1. Whether it was FOLLOWED (fully complied with)
+2. Whether it was VIOLATED (not followed)
+3. Whether it was PARTIALLY MET (some compliance but not complete)
+
+Consider these types of instructions:
+- Format requirements (JSON, markdown, bullet points, numbered lists, etc.)
+- Content constraints (required fields, topics to include/exclude, specific information)
+- Length/word count limits (maximum or minimum lengths)
+- Tone/style requirements (formal, casual, technical, etc.)
+- Structural requirements (sections, headings, ordering)
+- Explicit prohibitions (things to avoid or not mention)
+
+Scoring guidelines:
+- 1.0: All instructions fully followed
+- 0.8-0.99: Minor deviations that don't affect core compliance
+- 0.5-0.79: Some instructions followed, some violated or partially met
+- 0.2-0.49: Significant violations but some attempt at compliance
+- 0.0-0.19: Instructions largely ignored
+
+Severity levels:
+- "none": All instructions followed
+- "minor": Small deviations (e.g., slightly over word limit, minor formatting issues)
+- "major": Significant issues (e.g., wrong format, missing required content)
+- "critical": Fundamental violations (e.g., completely wrong output type, safety violations)
+
+Be thorough and precise in your analysis. List each distinct instruction and its status."""
+
+    def _get_user_prompt(
+        self, output: str, reference: Optional[str], criteria: Optional[str]
+    ) -> str:
+        """Get user prompt for specific evaluation."""
+        if not criteria:
+            raise ValueError(
+                "InstructionFollowingEvaluator requires criteria to be provided. "
+                "The criteria parameter should contain the instructions to check against."
+            )
+
+        prompt_parts = [f"OUTPUT TO EVALUATE:\n{output}\n"]
+
+        if reference:
+            prompt_parts.append(
+                f"REFERENCE/CONTEXT (for additional context, not instructions):\n"
+                f"{reference}\n"
+            )
+
+        prompt_parts.append(f"INSTRUCTIONS TO CHECK:\n{criteria}\n")
+
+        prompt_parts.append(
+            """Analyze how well the output follows the specified instructions.
+
+For your response:
+1. List each instruction that was successfully FOLLOWED
+2. List each instruction that was VIOLATED (not followed)
+3. List each instruction that was PARTIALLY MET
+4. Provide an overall score (0.0 to 1.0) reflecting instruction adherence
+5. Assess the violation severity ("none", "minor", "major", or "critical")
+6. Explain your reasoning in detail
+
+Be specific about which parts of the output correspond to which instructions."""
+        )
+
+        return "\n".join(prompt_parts)
+
+    def _get_response_type(self) -> Type[BaseModel]:
+        """Use instruction following response model."""
+        return InstructionFollowingResponse
+
+    async def _compute_score(self, response: BaseModel) -> Score:
+        """Extract Score from instruction following response."""
+        instruction_response = cast(InstructionFollowingResponse, response)
+
+        # Build detailed explanation
+        explanation_parts = [instruction_response.explanation]
+
+        if instruction_response.instructions_followed:
+            explanation_parts.append(
+                "\n\nInstructions Followed:\n- "
+                + "\n- ".join(instruction_response.instructions_followed)
+            )
+
+        if instruction_response.instructions_partially_met:
+            explanation_parts.append(
+                "\n\nInstructions Partially Met:\n- "
+                + "\n- ".join(instruction_response.instructions_partially_met)
+            )
+
+        if instruction_response.instructions_violated:
+            explanation_parts.append(
+                "\n\nInstructions Violated:\n- "
+                + "\n- ".join(instruction_response.instructions_violated)
+            )
+
+        full_explanation = "".join(explanation_parts)
+
+        return Score(
+            name=self.name,
+            value=instruction_response.score,
+            confidence=instruction_response.confidence,
+            explanation=full_explanation,
+            metadata={
+                "instructions_followed": instruction_response.instructions_followed,
+                "instructions_violated": instruction_response.instructions_violated,
+                "instructions_partially_met": (
+                    instruction_response.instructions_partially_met
+                ),
+                "followed_count": len(instruction_response.instructions_followed),
+                "violated_count": len(instruction_response.instructions_violated),
+                "partial_count": len(instruction_response.instructions_partially_met),
+                "violation_severity": instruction_response.violation_severity,
+            },
+        )

--- a/examples/instruction_following_example.py
+++ b/examples/instruction_following_example.py
@@ -1,0 +1,295 @@
+"""Example usage of InstructionFollowingEvaluator.
+
+This example demonstrates how to use the InstructionFollowingEvaluator to
+validate that LLM outputs adhere to specified instructions or constraints.
+
+The evaluator is critical for:
+- Agent output validation
+- Structured output compliance
+- Format requirement checking
+- Content constraint verification
+- Pipeline instruction adherence
+
+Run with: python examples/instruction_following_example.py
+
+Requires: OPENAI_API_KEY environment variable
+"""
+
+import asyncio
+import os
+from typing import Optional
+
+# Check for API key before importing arbiter_ai
+if not os.getenv("OPENAI_API_KEY"):
+    print("Error: OPENAI_API_KEY environment variable is required")
+    print("Set it with: export OPENAI_API_KEY=sk-...")
+    exit(1)
+
+from arbiter_ai import InstructionFollowingEvaluator, LLMManager, evaluate
+
+
+async def example_json_format_validation():
+    """Validate JSON format compliance."""
+    print("\n" + "=" * 60)
+    print("Example 1: JSON Format Validation")
+    print("=" * 60)
+
+    # Output that follows JSON instructions
+    good_output = '{"name": "Alice", "age": 30, "city": "New York"}'
+
+    # Output that violates JSON instructions
+    bad_output = "Name: Alice, Age: 30, City: New York"
+
+    instructions = (
+        "Respond in valid JSON format. "
+        "Include 'name', 'age', and 'city' fields. "
+        "Do not include any text outside the JSON object."
+    )
+
+    # Using the high-level API
+    print("\nEvaluating good output (valid JSON):")
+    result = await evaluate(
+        output=good_output,
+        criteria=instructions,
+        evaluators=["instruction_following"],
+        model="gpt-4o-mini",
+    )
+    print(f"  Score: {result.overall_score:.2f}")
+    print(f"  Cost: ${await result.total_llm_cost():.6f}")
+
+    print("\nEvaluating bad output (not JSON):")
+    result = await evaluate(
+        output=bad_output,
+        criteria=instructions,
+        evaluators=["instruction_following"],
+        model="gpt-4o-mini",
+    )
+    print(f"  Score: {result.overall_score:.2f}")
+    print(f"  Cost: ${await result.total_llm_cost():.6f}")
+
+
+async def example_multiple_constraints():
+    """Validate multiple content constraints."""
+    print("\n" + "=" * 60)
+    print("Example 2: Multiple Content Constraints")
+    print("=" * 60)
+
+    output = """Here is a brief summary:
+
+- The project uses Python for backend
+- React powers the frontend
+- PostgreSQL handles data storage
+
+In conclusion, this is a modern full-stack application."""
+
+    instructions = """
+    1. Keep response under 100 words
+    2. Use bullet points for the main content
+    3. Include a conclusion section
+    4. Do not use first person pronouns
+    """
+
+    client = await LLMManager.get_client(model="gpt-4o-mini")
+    evaluator = InstructionFollowingEvaluator(llm_client=client)
+
+    score = await evaluator.evaluate(output=output, criteria=instructions)
+
+    print(f"\nOutput:\n{output}")
+    print(f"\nInstructions:\n{instructions}")
+    print(f"\nScore: {score.value:.2f}")
+    print(f"Confidence: {score.confidence:.2f}")
+    print(f"Violation Severity: {score.metadata['violation_severity']}")
+    print(f"\nInstructions Followed: {score.metadata['instructions_followed']}")
+    print(f"Instructions Violated: {score.metadata['instructions_violated']}")
+    print(f"Instructions Partially Met: {score.metadata['instructions_partially_met']}")
+
+
+async def example_agent_output_validation():
+    """Validate agent tool use output."""
+    print("\n" + "=" * 60)
+    print("Example 3: Agent Tool Use Validation")
+    print("=" * 60)
+
+    # Simulated agent output from a customer service bot
+    agent_output = """I understand you're having trouble with your order.
+
+Let me look that up for you.
+
+Based on your order #12345, I can see it was shipped on January 15th
+and should arrive by January 20th.
+
+Is there anything else I can help you with today?"""
+
+    agent_instructions = """
+    As a customer service agent, you must:
+    1. Acknowledge the customer's concern
+    2. Reference the specific order number when available
+    3. Provide concrete next steps or information
+    4. End with an offer to help further
+    5. Maintain a professional and empathetic tone
+    6. Never make promises about refunds without authorization
+    """
+
+    result = await evaluate(
+        output=agent_output,
+        criteria=agent_instructions,
+        evaluators=["instruction_following"],
+        model="gpt-4o-mini",
+    )
+
+    print(f"\nAgent Output:\n{agent_output}")
+    print(f"\nCompliance Score: {result.overall_score:.2f}")
+
+    # Access detailed metrics
+    for score in result.scores:
+        print(f"\nViolation Severity: {score.metadata.get('violation_severity')}")
+        print(f"Followed ({score.metadata.get('followed_count', 0)}):")
+        for instruction in score.metadata.get("instructions_followed", []):
+            print(f"  - {instruction}")
+
+
+async def example_structured_output_compliance():
+    """Validate structured output requirements."""
+    print("\n" + "=" * 60)
+    print("Example 4: Structured Output Compliance")
+    print("=" * 60)
+
+    # API response that should follow specific structure
+    api_response = """{
+    "status": "success",
+    "data": {
+        "user_id": "usr_123",
+        "created_at": "2024-01-15T10:30:00Z",
+        "profile": {
+            "name": "John Doe",
+            "email": "john@example.com"
+        }
+    },
+    "metadata": {
+        "request_id": "req_abc123",
+        "processing_time_ms": 45
+    }
+}"""
+
+    structure_requirements = """
+    API response must:
+    1. Be valid JSON
+    2. Include a 'status' field with value 'success' or 'error'
+    3. Include a 'data' object with the response payload
+    4. Include a 'metadata' object with 'request_id' and 'processing_time_ms'
+    5. Use snake_case for all field names
+    6. Include ISO 8601 timestamps for any date fields
+    """
+
+    result = await evaluate(
+        output=api_response,
+        criteria=structure_requirements,
+        evaluators=["instruction_following"],
+        model="gpt-4o-mini",
+    )
+
+    print(f"\nAPI Response Structure Score: {result.overall_score:.2f}")
+    print(f"Evaluation Cost: ${await result.total_llm_cost():.6f}")
+
+
+async def example_with_reference_context():
+    """Validate output against instructions with reference context."""
+    print("\n" + "=" * 60)
+    print("Example 5: Instructions with Reference Context")
+    print("=" * 60)
+
+    # Original document (reference)
+    reference = """
+    Quarterly Financial Report - Q4 2024
+
+    Revenue: $10.5 million (up 15% YoY)
+    Operating Expenses: $7.2 million
+    Net Income: $2.1 million
+    Employee Count: 245
+
+    Key Achievements:
+    - Launched 3 new product lines
+    - Expanded to 5 new markets
+    - Achieved ISO 27001 certification
+    """
+
+    # Summary output to validate
+    output = """
+    Q4 2024 saw strong performance with revenue reaching $10.5M,
+    a 15% increase year-over-year. The company expanded operations
+    and launched new products while maintaining profitability.
+    """
+
+    instructions = """
+    Summarize the financial report following these rules:
+    1. Include the exact revenue figure
+    2. Mention the year-over-year growth percentage
+    3. Keep the summary under 50 words
+    4. Do not include specific employee counts
+    5. Focus on high-level achievements
+    """
+
+    client = await LLMManager.get_client(model="gpt-4o-mini")
+    evaluator = InstructionFollowingEvaluator(llm_client=client)
+
+    score = await evaluator.evaluate(
+        output=output,
+        reference=reference,
+        criteria=instructions,
+    )
+
+    print(f"\nReference Document: [Financial Report]")
+    print(f"\nSummary Output:\n{output}")
+    print(f"\nInstruction Adherence Score: {score.value:.2f}")
+    print(f"Violation Severity: {score.metadata['violation_severity']}")
+
+
+async def example_comparison_with_semantic():
+    """Compare instruction following with semantic evaluation."""
+    print("\n" + "=" * 60)
+    print("Example 6: Combining with Semantic Evaluation")
+    print("=" * 60)
+
+    output = "The capital of France is Paris, a beautiful city known for the Eiffel Tower."
+    reference = "Paris is the capital of France."
+    instructions = "Answer in one sentence. Do not include opinions or adjectives."
+
+    # Run both evaluators
+    result = await evaluate(
+        output=output,
+        reference=reference,
+        criteria=instructions,
+        evaluators=["semantic", "instruction_following"],
+        model="gpt-4o-mini",
+    )
+
+    print(f"\nOutput: {output}")
+    print(f"Reference: {reference}")
+    print(f"Instructions: {instructions}")
+    print(f"\nOverall Score: {result.overall_score:.2f}")
+
+    for score in result.scores:
+        print(f"\n{score.name}:")
+        print(f"  Score: {score.value:.2f}")
+        print(f"  Confidence: {score.confidence:.2f}")
+
+
+async def main():
+    """Run all examples."""
+    print("InstructionFollowingEvaluator Examples")
+    print("=" * 60)
+
+    await example_json_format_validation()
+    await example_multiple_constraints()
+    await example_agent_output_validation()
+    await example_structured_output_compliance()
+    await example_with_reference_context()
+    await example_comparison_with_semantic()
+
+    print("\n" + "=" * 60)
+    print("All examples completed!")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/unit/test_instruction_following.py
+++ b/tests/unit/test_instruction_following.py
@@ -1,0 +1,409 @@
+"""Unit tests for InstructionFollowingEvaluator."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from arbiter_ai.core.exceptions import EvaluatorError
+from arbiter_ai.evaluators.instruction_following import (
+    InstructionFollowingEvaluator,
+    InstructionFollowingResponse,
+)
+from tests.conftest import MockAgentResult
+
+
+@pytest.fixture
+def evaluator(mock_llm_client):
+    """Create an InstructionFollowingEvaluator instance."""
+    return InstructionFollowingEvaluator(llm_client=mock_llm_client)
+
+
+class TestInstructionFollowingEvaluator:
+    """Test suite for InstructionFollowingEvaluator."""
+
+    def test_name_property(self, evaluator):
+        """Test that evaluator has correct name."""
+        assert evaluator.name == "instruction_following"
+
+    def test_system_prompt(self, evaluator):
+        """Test that system prompt is well-formed."""
+        prompt = evaluator._get_system_prompt()
+        assert isinstance(prompt, str)
+        assert len(prompt) > 0
+        assert "instruction" in prompt.lower()
+        assert "followed" in prompt.lower()
+        assert "violated" in prompt.lower()
+
+    def test_user_prompt_with_criteria(self, evaluator):
+        """Test user prompt generation with criteria."""
+        output = '{"name": "Alice", "age": 30}'
+        criteria = "Respond in valid JSON. Include 'name' and 'age' fields."
+        prompt = evaluator._get_user_prompt(output, None, criteria)
+
+        assert output in prompt
+        assert criteria in prompt
+        assert "OUTPUT" in prompt
+        assert "INSTRUCTIONS" in prompt
+
+    def test_user_prompt_with_reference(self, evaluator):
+        """Test user prompt generation with reference context."""
+        output = "Summary of the document"
+        reference = "Original document content"
+        criteria = "Summarize in under 50 words"
+        prompt = evaluator._get_user_prompt(output, reference, criteria)
+
+        assert output in prompt
+        assert reference in prompt
+        assert criteria in prompt
+        assert "REFERENCE" in prompt or "CONTEXT" in prompt
+
+    def test_user_prompt_requires_criteria(self, evaluator):
+        """Test that user prompt requires criteria."""
+        with pytest.raises(ValueError) as exc_info:
+            evaluator._get_user_prompt("test output", None, None)
+
+        assert "criteria" in str(exc_info.value).lower()
+
+    def test_response_type(self, evaluator):
+        """Test that response type is correct."""
+        response_type = evaluator._get_response_type()
+        assert response_type == InstructionFollowingResponse
+
+    @pytest.mark.asyncio
+    async def test_compute_score_all_followed(self, evaluator):
+        """Test score computation when all instructions are followed."""
+        response = InstructionFollowingResponse(
+            score=1.0,
+            confidence=0.95,
+            explanation="All instructions were followed correctly",
+            instructions_followed=["Valid JSON format", "Contains name field"],
+            instructions_violated=[],
+            instructions_partially_met=[],
+            violation_severity="none",
+        )
+
+        score = await evaluator._compute_score(response)
+
+        assert score.name == "instruction_following"
+        assert score.value == 1.0
+        assert score.confidence == 0.95
+        assert "All instructions were followed" in score.explanation
+        assert "Instructions Followed" in score.explanation
+        assert score.metadata["followed_count"] == 2
+        assert score.metadata["violated_count"] == 0
+        assert score.metadata["violation_severity"] == "none"
+
+    @pytest.mark.asyncio
+    async def test_compute_score_with_violations(self, evaluator):
+        """Test score computation with instruction violations."""
+        response = InstructionFollowingResponse(
+            score=0.4,
+            confidence=0.88,
+            explanation="Some instructions were not followed",
+            instructions_followed=["Contains name field"],
+            instructions_violated=["Invalid JSON format", "Missing age field"],
+            instructions_partially_met=[],
+            violation_severity="major",
+        )
+
+        score = await evaluator._compute_score(response)
+
+        assert score.name == "instruction_following"
+        assert score.value == 0.4
+        assert score.confidence == 0.88
+        assert "Instructions Violated" in score.explanation
+        assert score.metadata["followed_count"] == 1
+        assert score.metadata["violated_count"] == 2
+        assert score.metadata["violation_severity"] == "major"
+
+    @pytest.mark.asyncio
+    async def test_compute_score_with_partial(self, evaluator):
+        """Test score computation with partially met instructions."""
+        response = InstructionFollowingResponse(
+            score=0.7,
+            confidence=0.82,
+            explanation="Mixed compliance with instructions",
+            instructions_followed=["Used JSON format"],
+            instructions_violated=[],
+            instructions_partially_met=["Word limit almost met"],
+            violation_severity="minor",
+        )
+
+        score = await evaluator._compute_score(response)
+
+        assert score.name == "instruction_following"
+        assert score.value == 0.7
+        assert "Instructions Partially Met" in score.explanation
+        assert score.metadata["partial_count"] == 1
+        assert score.metadata["violation_severity"] == "minor"
+
+    @pytest.mark.asyncio
+    async def test_evaluate_with_criteria(self, evaluator, mock_agent):
+        """Test evaluation with criteria."""
+        mock_response = InstructionFollowingResponse(
+            score=0.92,
+            confidence=0.9,
+            explanation="Instructions well followed",
+            instructions_followed=["JSON format", "Contains required fields"],
+            instructions_violated=[],
+            instructions_partially_met=[],
+            violation_severity="none",
+        )
+
+        mock_result = MockAgentResult(mock_response)
+        mock_agent.run = AsyncMock(return_value=mock_result)
+        evaluator.llm_client.create_agent = MagicMock(return_value=mock_agent)
+
+        score = await evaluator.evaluate(
+            output='{"name": "Alice", "age": 30}',
+            criteria="Respond in valid JSON. Include 'name' and 'age' fields.",
+        )
+
+        assert score.value == 0.92
+        assert score.confidence == 0.9
+        assert len(evaluator.interactions) == 1
+        assert evaluator.interactions[0].purpose == "instruction_following_evaluation"
+
+    @pytest.mark.asyncio
+    async def test_evaluate_without_criteria_raises(self, evaluator, mock_agent):
+        """Test that evaluation without criteria raises ValueError."""
+        mock_agent.run = AsyncMock()
+        evaluator.llm_client.create_agent = MagicMock(return_value=mock_agent)
+
+        with pytest.raises(EvaluatorError) as exc_info:
+            await evaluator.evaluate(output='{"name": "Alice"}')
+
+        assert "criteria" in str(exc_info.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_evaluate_error_handling(self, evaluator, mock_agent):
+        """Test error handling during evaluation."""
+        mock_agent.run = AsyncMock(side_effect=Exception("LLM API error"))
+        evaluator.llm_client.create_agent = MagicMock(return_value=mock_agent)
+
+        with pytest.raises(EvaluatorError) as exc_info:
+            await evaluator.evaluate(
+                output="Test output",
+                criteria="Test criteria",
+            )
+
+        assert "instruction_following" in str(exc_info.value)
+        assert "Evaluation failed" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_interaction_tracking(self, evaluator, mock_agent):
+        """Test that LLM interactions are tracked."""
+        mock_response = InstructionFollowingResponse(
+            score=0.85,
+            confidence=0.88,
+            explanation="Test explanation",
+            instructions_followed=["Test instruction"],
+            instructions_violated=[],
+            instructions_partially_met=[],
+            violation_severity="none",
+        )
+
+        mock_result = MockAgentResult(mock_response)
+        mock_agent.run = AsyncMock(return_value=mock_result)
+        evaluator.llm_client.create_agent = MagicMock(return_value=mock_agent)
+
+        await evaluator.evaluate(
+            output="Test output",
+            criteria="Test criteria",
+        )
+
+        assert len(evaluator.interactions) == 1
+        interaction = evaluator.interactions[0]
+        assert interaction.model == "gpt-4o-mini"
+        assert interaction.purpose == "instruction_following_evaluation"
+        assert interaction.tokens_used == 100
+        assert interaction.metadata["evaluator"] == "instruction_following"
+        assert interaction.metadata["has_reference"] is False
+        assert interaction.metadata["has_criteria"] is True
+
+    @pytest.mark.asyncio
+    async def test_evaluate_with_reference(self, evaluator, mock_agent):
+        """Test evaluation with reference context."""
+        mock_response = InstructionFollowingResponse(
+            score=0.75,
+            confidence=0.8,
+            explanation="Instructions mostly followed",
+            instructions_followed=["Summarized content"],
+            instructions_violated=[],
+            instructions_partially_met=["Length slightly over"],
+            violation_severity="minor",
+        )
+
+        mock_result = MockAgentResult(mock_response)
+        mock_agent.run = AsyncMock(return_value=mock_result)
+        evaluator.llm_client.create_agent = MagicMock(return_value=mock_agent)
+
+        score = await evaluator.evaluate(
+            output="Brief summary of the document",
+            reference="Full document text here",
+            criteria="Summarize in under 10 words",
+        )
+
+        assert score.value == 0.75
+        assert len(evaluator.interactions) == 1
+        assert evaluator.interactions[0].metadata["has_reference"] is True
+
+
+class TestInstructionFollowingResponse:
+    """Test suite for InstructionFollowingResponse model."""
+
+    def test_response_creation(self):
+        """Test creating an InstructionFollowingResponse."""
+        response = InstructionFollowingResponse(
+            score=0.85,
+            confidence=0.9,
+            explanation="Test explanation",
+            instructions_followed=["Instruction 1"],
+            instructions_violated=["Instruction 2"],
+            instructions_partially_met=[],
+            violation_severity="minor",
+        )
+
+        assert response.score == 0.85
+        assert response.confidence == 0.9
+        assert response.explanation == "Test explanation"
+        assert response.instructions_followed == ["Instruction 1"]
+        assert response.instructions_violated == ["Instruction 2"]
+        assert response.violation_severity == "minor"
+
+    def test_response_defaults(self):
+        """Test InstructionFollowingResponse default values."""
+        response = InstructionFollowingResponse(
+            score=0.8,
+            explanation="Test",
+        )
+
+        assert response.score == 0.8
+        assert response.confidence == 0.85  # Default
+        assert response.instructions_followed == []
+        assert response.instructions_violated == []
+        assert response.instructions_partially_met == []
+        assert response.violation_severity == "none"
+
+    def test_response_score_validation(self):
+        """Test that score must be between 0 and 1."""
+        # Valid scores
+        InstructionFollowingResponse(score=0.0, explanation="test")
+        InstructionFollowingResponse(score=1.0, explanation="test")
+        InstructionFollowingResponse(score=0.5, explanation="test")
+
+        # Invalid scores
+        with pytest.raises(Exception):  # Pydantic validation error
+            InstructionFollowingResponse(score=-0.1, explanation="test")
+
+        with pytest.raises(Exception):  # Pydantic validation error
+            InstructionFollowingResponse(score=1.1, explanation="test")
+
+    def test_response_severity_validation(self):
+        """Test that violation severity must be valid."""
+        # Valid severities
+        InstructionFollowingResponse(
+            score=1.0, explanation="test", violation_severity="none"
+        )
+        InstructionFollowingResponse(
+            score=0.8,
+            explanation="test",
+            violation_severity="minor",
+            instructions_partially_met=["Some partial"],
+        )
+        InstructionFollowingResponse(
+            score=0.5,
+            explanation="test",
+            violation_severity="major",
+            instructions_violated=["Some violation"],
+        )
+        InstructionFollowingResponse(
+            score=0.1,
+            explanation="test",
+            violation_severity="critical",
+            instructions_violated=["Critical violation"],
+        )
+
+        # Invalid severity
+        with pytest.raises(Exception):  # Pydantic validation error
+            InstructionFollowingResponse(
+                score=0.5, explanation="test", violation_severity="invalid"
+            )
+
+    def test_response_explanation_required(self):
+        """Test that explanation cannot be empty."""
+        with pytest.raises(Exception):  # Pydantic validation error
+            InstructionFollowingResponse(score=0.5, explanation="")
+
+        with pytest.raises(Exception):  # Pydantic validation error
+            InstructionFollowingResponse(score=0.5, explanation="   ")
+
+    def test_severity_consistency_validation(self):
+        """Test that violation severity is consistent with instruction counts."""
+        # Valid: no violations with 'none' severity
+        InstructionFollowingResponse(
+            score=1.0,
+            explanation="All good",
+            instructions_followed=["All followed"],
+            instructions_violated=[],
+            violation_severity="none",
+        )
+
+        # Invalid: violations exist but severity is 'none'
+        with pytest.raises(ValueError) as exc_info:
+            InstructionFollowingResponse(
+                score=0.5,
+                explanation="Has violations",
+                instructions_followed=[],
+                instructions_violated=["Something violated"],
+                violation_severity="none",
+            )
+        assert "none" in str(exc_info.value).lower()
+
+    def test_severity_allows_minor_without_violations(self):
+        """Test that 'minor' severity is allowed even without explicit violations."""
+        # This is valid because minor issues might not be explicitly listed
+        response = InstructionFollowingResponse(
+            score=0.9,
+            explanation="Minor formatting issues",
+            instructions_followed=["Main instruction"],
+            instructions_violated=[],
+            instructions_partially_met=[],
+            violation_severity="minor",
+        )
+        assert response.violation_severity == "minor"
+
+    def test_severity_disallows_major_without_any_issues(self):
+        """Test that major/critical requires violations or partial compliance."""
+        with pytest.raises(ValueError):
+            InstructionFollowingResponse(
+                score=0.9,
+                explanation="Claims major issues but lists none",
+                instructions_followed=["All followed"],
+                instructions_violated=[],
+                instructions_partially_met=[],
+                violation_severity="major",
+            )
+
+
+class TestInstructionFollowingRegistry:
+    """Test that InstructionFollowingEvaluator is registered correctly."""
+
+    def test_evaluator_in_registry(self):
+        """Test that evaluator is available in registry."""
+        from arbiter_ai.core.registry import (
+            get_available_evaluators,
+            get_evaluator_class,
+        )
+
+        evaluators = get_available_evaluators()
+        assert "instruction_following" in evaluators
+
+        evaluator_class = get_evaluator_class("instruction_following")
+        assert evaluator_class is InstructionFollowingEvaluator
+
+    def test_evaluator_importable_from_package(self):
+        """Test that evaluator is importable from main package."""
+        from arbiter_ai import InstructionFollowingEvaluator as ImportedEvaluator
+
+        assert ImportedEvaluator is InstructionFollowingEvaluator


### PR DESCRIPTION
## Summary

Adds `InstructionFollowingEvaluator` that measures how well LLM outputs adhere to specified instructions or constraints. This is critical for:

- Validating agent outputs follow specific formats (JSON, markdown, etc.)
- Checking structured output compliance
- Ensuring content constraints are met (required fields, length limits)
- Verifying tone/style requirements
- Testing LLM pipelines with explicit instructions

## Changes

- New evaluator: `arbiter_ai/evaluators/instruction_following.py`
- Response model with instruction tracking (followed, violated, partially_met)
- Violation severity levels (none, minor, major, critical)
- Registered in evaluator registry
- Exported from main package
- Unit tests (100% coverage on new code)
- Example file demonstrating 6 use cases

## Usage

```python
from arbiter_ai import evaluate

result = await evaluate(
    output='{"name": "Alice", "age": 30}',
    criteria="Respond in valid JSON. Include 'name' and 'age' fields.",
    evaluators=["instruction_following"],
    model="gpt-4o-mini"
)

print(f"Score: {result.overall_score:.2f}")
# Access detailed metrics
for score in result.scores:
    print(f"Followed: {score.metadata['instructions_followed']}")
    print(f"Violated: {score.metadata['instructions_violated']}")
```

## Test plan

- [x] All 969 tests pass
- [x] 96% overall coverage maintained
- [x] 100% coverage on new evaluator code
- [x] `make all` passes (format, lint, type-check, test)
- [x] Exports work correctly from main package
- [x] Evaluator registered in registry

Closes #38